### PR TITLE
Optimize hooks a little

### DIFF
--- a/packages/leyden-react/src/hooks/useAreCoordinatesSelected.ts
+++ b/packages/leyden-react/src/hooks/useAreCoordinatesSelected.ts
@@ -1,0 +1,29 @@
+import { Coordinates, LeydenEditor } from 'leyden';
+import { useEffect, useState } from 'react';
+
+import { useLeydenStatic } from './useLeydenStatic';
+
+export const useAreCoordinatesSelected = (coords: Coordinates|null): boolean => {
+    const editor = useLeydenStatic();
+    const currentSelectedCoords = LeydenEditor.selectedCoords(editor);
+    const [coordinatesSelected, setCoordinatesSelected] = useState(
+        (coords && currentSelectedCoords) ?
+            Coordinates.equals(currentSelectedCoords, coords) :
+            false
+    );
+
+    useEffect(() => {
+        const unsubscribe = LeydenEditor.subscribeToSelectedCoordinatesByCoordinates(
+            editor,
+            setCoordinatesSelected,
+            {
+                at: coords
+            },
+        );
+        return () => {
+            unsubscribe();
+        };
+    }, []);
+
+    return coordinatesSelected;
+};

--- a/packages/leyden-react/src/hooks/useCellIsSelected.ts
+++ b/packages/leyden-react/src/hooks/useCellIsSelected.ts
@@ -1,21 +1,10 @@
-import { Coordinates } from 'leyden';
-import { useMemo } from 'react';
 import { Descendant } from 'slate';
 
 import { useCoordinates } from './useCoordinates';
-import { useSelectedCoordinates } from './useSelectedCoordinates';
+import { useAreCoordinatesSelected } from './useAreCoordinatesSelected';
 
 export const useCellIsSelected = (node: Descendant): boolean => {
     const ownCoords = useCoordinates(node);
-    const selectedCoords = useSelectedCoordinates();
 
-    const cellSelected = useMemo(() => {
-        return (
-            ownCoords !== null
-            && selectedCoords !== null
-            && Coordinates.equals(ownCoords, selectedCoords)
-        );
-    }, [ownCoords, selectedCoords]);
-
-    return cellSelected;
+    return useAreCoordinatesSelected(ownCoords);
 };

--- a/packages/leyden-react/src/hooks/useCoordinates.ts
+++ b/packages/leyden-react/src/hooks/useCoordinates.ts
@@ -23,15 +23,13 @@ export const useCoordinates = (node: Descendant): Coordinates|null => {
                 return;
             }
             // If not wrapped in `setTimeout`, this runs before the cell paths are updated
-            // and coordinate movement is never detected. 
-            setTimeout(() => {
-                const newCoords = ReactEditor.cellCoords(editor, node);
-                if ((newCoords === null || !Coordinates.equals(coordinates, newCoords))
-                    && !canceled
-                ) {
-                    setCoordinates(newCoords);
-                }
-            });
+            // and coordinate movement is never detected.
+            const newCoords = ReactEditor.cellCoords(editor, node);
+            if ((newCoords === null || !Coordinates.equals(coordinates, newCoords))
+                && !canceled
+            ) {
+                setCoordinates(newCoords);
+            }
         });
         return () => {
             canceled = true;

--- a/packages/leyden/src/interfaces/LeydenEditor.ts
+++ b/packages/leyden/src/interfaces/LeydenEditor.ts
@@ -338,8 +338,7 @@ export const LeydenEditor: LeydenEditorInterface = {
     },
 
     /**
-     * Subscribe to the table's currently selected coordinates, or null if
-     * there is no active selection.
+     * Subscribe to the selected status of a cell at the specified coordinates.
      */
 
     subscribeToSelectedCoordinatesByCoordinates(

--- a/packages/leyden/src/interfaces/LeydenEditor.ts
+++ b/packages/leyden/src/interfaces/LeydenEditor.ts
@@ -359,7 +359,7 @@ export const LeydenEditor: LeydenEditorInterface = {
                 Path.equals(op.newProperties?.focus?.path.slice(0, 2), cellPath)
             ) {
                 subscriber(true);
-            } else {
+            } else if (Operation.isSelectionOperation(op)) {
                 subscriber(false);
             }
         });

--- a/packages/leyden/src/utils/types.ts
+++ b/packages/leyden/src/utils/types.ts
@@ -39,13 +39,19 @@ export type CellSubscriber<T extends CellType> = (cell: Cell<T>) => void;
 export type SelectedCoordinatesSubscriber = (coords: Coordinates|null) => void;
 
 /**
- * A function which will end a subscription 
+ * A function fired when the current cell's coordinates become selected.
+ */
+
+export type CoordinateSelectedSubscriber = (selected: boolean) => void;
+
+/**
+ * A function which will end a subscription
  */
 
 export type Unsubscriber = () => void;
 
 /**
- * An option representing a leyden editor passed during editor initialization 
+ * An option representing a leyden editor passed during editor initialization
  */
 
 export interface EditorOption<T extends Editor> {
@@ -53,7 +59,7 @@ export interface EditorOption<T extends Editor> {
 }
 
 /**
- * An option representing a validator set passed during editor initialization 
+ * An option representing a validator set passed during editor initialization
  */
 
 export interface ValidatorsOption {

--- a/packages/leyden/src/withLeyden.ts
+++ b/packages/leyden/src/withLeyden.ts
@@ -35,13 +35,15 @@ export const withLeyden = <T extends Editor>({ editor, ...rest }: WithLeydenOpti
             }
         }
         apply(op);
-        // Notify subscribers of operations after application
-        const opSubscribers = OPERATION_SUBSCRIBERS.get(e);
-        if (opSubscribers !== undefined) {
-            for (const opSubscriber of opSubscribers) {
-                opSubscriber(op);
+        setTimeout(() => {
+            // Notify subscribers of operations after application
+            const opSubscribers = OPERATION_SUBSCRIBERS.get(e);
+            if (opSubscribers !== undefined) {
+                for (const opSubscriber of opSubscribers) {
+                    opSubscriber(op);
+                }
             }
-        }
+        });
     };
 
     e.getValidationFunc = validator => (

--- a/packages/leyden/src/withLeyden.ts
+++ b/packages/leyden/src/withLeyden.ts
@@ -1,4 +1,5 @@
-import { Editor, Node } from 'slate';
+import { BaseOperation, Editor, Node } from 'slate';
+import { debounce } from 'lodash';
 
 import { LeydenEditor } from './interfaces/LeydenEditor';
 import { Element } from './interfaces/Element';
@@ -35,8 +36,9 @@ export const withLeyden = <T extends Editor>({ editor, ...rest }: WithLeydenOpti
             }
         }
         apply(op);
+
+        // Notify subscribers of operations after application
         setTimeout(() => {
-            // Notify subscribers of operations after application
             const opSubscribers = OPERATION_SUBSCRIBERS.get(e);
             if (opSubscribers !== undefined) {
                 for (const opSubscriber of opSubscribers) {

--- a/packages/leyden/src/withLeyden.ts
+++ b/packages/leyden/src/withLeyden.ts
@@ -1,5 +1,4 @@
-import { BaseOperation, Editor, Node } from 'slate';
-import { debounce } from 'lodash';
+import { Editor, Node } from 'slate';
 
 import { LeydenEditor } from './interfaces/LeydenEditor';
 import { Element } from './interfaces/Element';


### PR DESCRIPTION
## Overview

This is a tricky one because I don't know if it 100% works.

Basically the premise is to do two things:

1. Remove the `setTimeout` logic out of `useCoordinates` and move it to the `apply` wrapper. Thanks to that, way less time is spent just waiting for the timeout to happen.
2. Introduce a new `useAreCoordinatesSelected` hook to mitigate the need to run heavy comparison for every cell click in `useCellIsSelected`. Now it's going to return a boolean and should make things quicker for larger tables.

## Risks

Point 1. is the risk-prone one. I've experimented with a couple of possible solutions, including using `lodash.debounce` instead of `setTimeout`, but then I ended up at what's in the PR and it still worked, so I stayed with that. I have not seen it do anything weird but then again, testing npm packages locally isn't an easy task.

If we vote against Point 1, Point 2 definitely seems like an easy win, and I'd be happy to cherry-pick just that change.

## Testing

See if coordinates stay updated. Monitor the speed of `useCellIsSelected`.
